### PR TITLE
Use jsdelivr as CDN for browser SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ const newsletter = await cloudnode.newsletter.get("newsletter_123asd");
 #### Browser
 Download the browser SDK from `browser/Cloudnode.js` or use our hosted version.
 ```html
-<script src="https://cloudnode.pro/assets/js/sdk.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/cloudnode-ts@latest/browser/Cloudnode.min.js"></script>
 <script>
 const cloudnode = new Cloudnode();
 

--- a/gen/config.json
+++ b/gen/config.json
@@ -3,5 +3,5 @@
   "instanceName": "cloudnode",
   "baseUrl": "https://api.cloudnode.pro/v5/",
   "apiVersion": "5.7.1",
-  "browserSdkUrl": "https://cloudnode.pro/assets/js/sdk.min.js"
+  "browserSdkUrl": "https://cdn.jsdelivr.net/npm/cloudnode-ts@latest/browser/Cloudnode.min.js"
 }


### PR DESCRIPTION
just replaces the url in the config and the readme