### PR TITLE
Stricter TypeScript compiler options

### DIFF
--- a/browser/Cloudnode.js
+++ b/browser/Cloudnode.js
@@ -91,7 +91,7 @@ class Cloudnode {
         const text = await response.text();
         let data;
         if (response.headers.get("Content-Type")?.startsWith("application/json")) {
-            data = JSON.parse(text, (key, value) => {
+            data = JSON.parse(text, (_key, value) => {
                 // parse dates
                 if (/^\d{4}-\d{2}-\d{2}T(?:\d{2}:){2}\d{2}(?:\.\d+)?(?:[a-zA-Z]+|\+\d{2}:\d{2})?$/.test(value))
                     return new Date(value);

--- a/gen/DocSchema.ts
+++ b/gen/DocSchema.ts
@@ -7,13 +7,13 @@ interface DocSchema {
 }
 
 namespace DocSchema {
-    export class Entry {
+    export abstract class Entry {
         public name: string;
         public readonly type: string;
         public readonly typeName?: string;
         public readonly isStatic?: true;
 
-        constructor(name: string, type: string, isStatic?: true, alwaysTypeName?: true) {
+        protected constructor(name: string, type: string, isStatic?: true, alwaysTypeName?: true) {
             this.name = name;
             this.type = type;
             this.isStatic = isStatic;
@@ -28,9 +28,7 @@ namespace DocSchema {
             return this.displayName.toLowerCase().replace(/[^a-z\d\s]/g, "").replace(/\s+/g, "-");
         }
 
-        public content(config: Config, schema: Schema): string {
-            return "";
-        }
+        public abstract content(config: Config, schema: Schema): string;
     }
 
     export class Property extends Entry {

--- a/gen/browser.ts
+++ b/gen/browser.ts
@@ -10,7 +10,6 @@ export async function createBrowserSDK(config: Config): Promise<void> {
     // remove imports at beginning of file and export default at end of file
     const browserJs = mainJs.replace(/^import.*$/gm, "").replace(/^export default \w+;$/gm, "");
     // evaluate the code to verify it works
-    const fetch = () => {};
     eval(browserJs);
     // create folder `/browser` if it doesn't exist
     try {

--- a/gen/docs.ts
+++ b/gen/docs.ts
@@ -178,7 +178,7 @@ export function linkType (type: string, config: Config, schema: Schema): string 
         else {
             // if it includes a generic, link the generic
             const parts = typeName.match(/<(.*)>/);
-            if (parts) return `${link(typeName.slice(0, parts.index))}<${fullLink(parts[1])}>`;
+            if (parts && parts[1]) return `${link(typeName.slice(0, parts.index))}<${fullLink(parts[1])}>`;
         }
         return link(typeName);
     };

--- a/gen/docs.ts
+++ b/gen/docs.ts
@@ -63,7 +63,7 @@ export function generateDocSchema (schema: Schema, config: Config, pkg: Package)
     }
     // make operations into methods
     const operationMethods = operations.map(operation => {
-        const returns = {type: getReturnType(operation, schema, config), description: getReturnDescription(operation, schema, config)};
+        const returns = {type: getReturnType(operation, schema, config), description: getReturnDescription(operation)};
         const throws = getThrows(operation, schema, config).map(type => ({type}));
         const pathParams = Object.entries(operation.parameters.path ?? {}).map(([name, parameter]) => new DocSchema.Parameter(name, parameter.type, parameter.description, parameter.required, parameter.default));
         const queryParams = Object.entries(operation.parameters.query ?? {}).map(([name, parameter]) => new DocSchema.Parameter(name, parameter.type, parameter.description, parameter.required, parameter.default));
@@ -233,8 +233,8 @@ export function generateMarkdownDocs (config: Config, schema: Schema, docSchema:
 export async function generateReadme (docMD: string, config: Config, pkg: Package): Promise<void> {
     const template = await fs.readFile("README.template.md", "utf8");
     // check if project builds successfully
-    const buildStatus = await new Promise((resolve, reject) => {
-        child_process.exec("npm run build", (error, stdout, stderr) => {
+    const buildStatus = await new Promise((resolve) => {
+        child_process.exec("npm run build", (error) => {
             resolve(!error);
         });
     });

--- a/gen/source.ts
+++ b/gen/source.ts
@@ -86,12 +86,12 @@ export default async (schema: Schema, config: Config, pkg: Package) => {
 
     // get operation namespaces
     const namespaces: FlatNamespace[] = [];
-    for (const [name, namespace] of Object.entries(schema.operations).filter(([name, operation]) => operation.type === "namespace") as [string, Schema.Operation.Namespace][]) {
+    for (const [name, namespace] of Object.entries(schema.operations).filter(([_name, operation]) => operation.type === "namespace") as [string, Schema.Operation.Namespace][]) {
         namespaces.push({name, operations: flatOperations(Object.entries(namespace.operations))});
     }
 
     // get operations without namespace
-    const operations = flatOperations(Object.entries(schema.operations).filter(([name, operation]) => operation.type !== "namespace") as [string, Schema.Operation][]);
+    const operations = flatOperations(Object.entries(schema.operations).filter(([_name, operation]) => operation.type !== "namespace") as [string, Schema.Operation][]);
 
     // load render main class from `/gen/templates/main.mustache`
     const mainTemplate = await fs.readFile(path.join("gen", "templates", "main.mustache"), "utf8");

--- a/gen/source.ts
+++ b/gen/source.ts
@@ -44,7 +44,7 @@ export default async (schema: Schema, config: Config, pkg: Package) => {
         const operations: FlatOperation[] = [];
         for (const [name, operation] of input) {
             const returnType = getReturnType(operation, schema, config);
-            const returnDescription = getReturnDescription(operation, schema, config);
+            const returnDescription = getReturnDescription(operation);
             const toFlatParam = ([name, parameter]: [string, Schema.Operation.Parameter]): NamedParameter => {
                 const ts = `${name}${!parameter.required && !parameter.default ? "?: " : ": "}${parameter.type}${parameter.default ? ` = ${parameter.default}` : ""}`;
                 return {name, ts, ...parameter};

--- a/gen/templates/main.mustache
+++ b/gen/templates/main.mustache
@@ -102,7 +102,7 @@ class {{config.name}} {
         const text = await response.text();
         let data: T;
         if (response.headers.get("Content-Type")?.startsWith("application/json")) {
-            data = JSON.parse(text, (key, value) => {
+            data = JSON.parse(text, (_key, value) => {
                 // parse dates
                 if (/^\d{4}-\d{2}-\d{2}T(?:\d{2}:){2}\d{2}(?:\.\d+)?(?:[a-zA-Z]+|\+\d{2}:\d{2})?$/.test(value))
                     return new Date(value);

--- a/gen/util.ts
+++ b/gen/util.ts
@@ -85,11 +85,11 @@ function addExtraReturnsToOperation(operation: Schema.Operation): Schema.Operati
  */
 export function replaceModelTypes(schema: Schema, config: Config): Schema {
     for (const modelID in schema.models) {
-        const model = schema.models[modelID];
+        const model = schema.models[modelID]!;
         for (const fieldID in model.fields) {
-            const field = model.fields[fieldID];
+            const field = model.fields[fieldID]!;
             if (schema.models.find(m => m.name === field.type))
-                schema.models[modelID].fields[fieldID].type = `${config.name}.${field.type}`;
+                schema.models[modelID]!.fields[fieldID]!.type = `${config.name}.${field.type}`;
         }
     }
     return schema;

--- a/gen/util.ts
+++ b/gen/util.ts
@@ -19,7 +19,7 @@ export function getReturnType(operation: Schema.Operation, schema: Schema, confi
  * @param config
  * @returns The combined return description
  */
-export function getReturnDescription(operation: Schema.Operation, schema: Schema, config: Config): string {
+export function getReturnDescription(operation: Schema.Operation): string {
     return operation.returns.filter(r => r.status >= 200 && r.status < 300 && r.description).map(r => r.description).join(" ");
 }
 

--- a/src/Cloudnode.js
+++ b/src/Cloudnode.js
@@ -91,7 +91,7 @@ class Cloudnode {
         const text = await response.text();
         let data;
         if (response.headers.get("Content-Type")?.startsWith("application/json")) {
-            data = JSON.parse(text, (key, value) => {
+            data = JSON.parse(text, (_key, value) => {
                 // parse dates
                 if (/^\d{4}-\d{2}-\d{2}T(?:\d{2}:){2}\d{2}(?:\.\d+)?(?:[a-zA-Z]+|\+\d{2}:\d{2})?$/.test(value))
                     return new Date(value);

--- a/src/Cloudnode.ts
+++ b/src/Cloudnode.ts
@@ -102,7 +102,7 @@ class Cloudnode {
         const text = await response.text();
         let data: T;
         if (response.headers.get("Content-Type")?.startsWith("application/json")) {
-            data = JSON.parse(text, (key, value) => {
+            data = JSON.parse(text, (_key, value) => {
                 // parse dates
                 if (/^\d{4}-\d{2}-\d{2}T(?:\d{2}:){2}\d{2}(?:\.\d+)?(?:[a-zA-Z]+|\+\d{2}:\d{2})?$/.test(value))
                     return new Date(value);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     /* Visit https://aka.ms/tsconfig to read more about this file */
 
     /* Projects */
-    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+    "incremental": true,                                 /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
     // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
     // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
     // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
@@ -53,7 +53,7 @@
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
-    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
+    "importsNotUsedAsValues": "remove",                  /* Specify emit/checking behavior for imports that are only used for types. */
     // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
     // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
     // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
@@ -61,9 +61,9 @@
     // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
     // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
     // "newLine": "crlf",                                /* Set the newline character for emitting files. */
-    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+    "stripInternal": true,                               /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
     // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
-    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    "noEmitOnError": true,                               /* Disable emitting files if any type checking errors are reported. */
     // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
     // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
     // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
@@ -72,29 +72,29 @@
     // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
     "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
-    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "preserveSymlinks": true,                            /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
     "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
 
     /* Type Checking */
     "strict": true,                                      /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
-    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
-    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
-    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
-    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+    "noImplicitAny": true,                               /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    "strictNullChecks": true,                            /* When type checking, take into account 'null' and 'undefined'. */
+    "strictFunctionTypes": true,                         /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    "strictBindCallApply": true,                         /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+    "strictPropertyInitialization": true,                /* Check for class properties that are declared but not set in the constructor. */
+    "noImplicitThis": true,                              /* Enable error reporting when 'this' is given the type 'any'. */
     // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
-    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
-    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
-    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+    "alwaysStrict": true,                                /* Ensure 'use strict' is always emitted. */
+    "noUnusedLocals": true,                              /* Enable error reporting when local variables aren't read. */
+    "noUnusedParameters": true,                          /* Raise an error when a function parameter isn't read. */
     // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
-    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    "noImplicitReturns": true,                           /* Enable error reporting for codepaths that do not explicitly return in a function. */
     // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
-    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
-    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
-    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
-    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
-    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+    "noUncheckedIndexedAccess": true,                    /* Add 'undefined' to a type when accessed using an index. */
+    "noImplicitOverride": true,                          /* Ensure overriding members in derived classes are marked with an override modifier. */
+    "noPropertyAccessFromIndexSignature": true,          /* Enforces using indexed accessors for keys declared using an indexed type. */
+    "allowUnusedLabels": true,                           /* Disable error reporting for unused labels. */
+    "allowUnreachableCode": true,                        /* Disable error reporting for unreachable code. */
 
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -92,7 +92,7 @@
     // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
     "noUncheckedIndexedAccess": true,                    /* Add 'undefined' to a type when accessed using an index. */
     "noImplicitOverride": true,                          /* Ensure overriding members in derived classes are marked with an override modifier. */
-    "noPropertyAccessFromIndexSignature": true,          /* Enforces using indexed accessors for keys declared using an indexed type. */
+    "noPropertyAccessFromIndexSignature": false,         /* Enforces using indexed accessors for keys declared using an indexed type. */
     "allowUnusedLabels": true,                           /* Disable error reporting for unused labels. */
     "allowUnreachableCode": true,                        /* Disable error reporting for unreachable code. */
 


### PR DESCRIPTION
Enable the strictest compiler options (known to me) in `tsconfig.json`.

Includes code modifications to resolve errors from the new, stricter options.

If I‘ve missed a strict option, do let me know.