### PR TITLE
Rename from "SDK" to client/library

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ console.log(newsletter._response.status); // 200
 #### Browser
 Download the browser version from `browser/Cloudnode.js` or use our hosted version.
 ```html
-<script src=""></script>
+<script src="https://cdn.jsdelivr.net/npm/cloudnode-ts@latest/browser/Cloudnode.min.js"></script>
 <script>
 const cloudnode = new Cloudnode();
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Cloudnode API SDK
+# Cloudnode API Client
 
 ![Client Version: 2.1.0](https://img.shields.io/badge/Client%20Version-2.1.0-%2316a34a)
 ![API Version: 5.12.0](https://img.shields.io/badge/API%20Version-5.12.0-%232563eb)
 ![build: passing](https://img.shields.io/badge/build-passing-%2316a34a)
 ![npm downloads](https://img.shields.io/npm/dt/cloudnode-ts?label=downloads)
 
-A client SDK for the Cloudnode API, written in TypeScript. [Documentation](https:&#x2F;&#x2F;github.com&#x2F;cloudnode-pro&#x2F;ts-client#documentation)
+A client library for the Cloudnode API, written in TypeScript. [Documentation](https:&#x2F;&#x2F;github.com&#x2F;cloudnode-pro&#x2F;ts-client#documentation)
 
 ## Install
 ```shell
@@ -38,9 +38,9 @@ console.log(newsletter._response.status); // 200
 ```
 
 #### Browser
-Download the browser SDK from `browser/Cloudnode.js` or use our hosted version.
+Download the browser version from `browser/Cloudnode.js` or use our hosted version.
 ```html
-<script src="https://cdn.jsdelivr.net/npm/cloudnode-ts@latest/browser/Cloudnode.min.js"></script>
+<script src=""></script>
 <script>
 const cloudnode = new Cloudnode();
 
@@ -136,7 +136,7 @@ console.log(newsletter._response.status); // 200
 
 ## Class: `Cloudnode`
 
-A client SDK for the Cloudnode API, written in TypeScript. [Documentation](https://github.com/cloudnode-pro/ts-client#documentation)
+A client library for the Cloudnode API, written in TypeScript. [Documentation](https://github.com/cloudnode-pro/ts-client#documentation)
 
 <a name="new-cloudnodetoken-options"></a>
 
@@ -647,7 +647,7 @@ Refresh current token. The token that was used to authenticate the request will 
 
 ## Namespace: `Cloudnode`
 
-A client SDK for the Cloudnode API, written in TypeScript. [Documentation](https://github.com/cloudnode-pro/ts-client#documentation)
+A client library for the Cloudnode API, written in TypeScript. [Documentation](https://github.com/cloudnode-pro/ts-client#documentation)
 
 <a name="class-cloudnodeapiresponset"></a>
 

--- a/README.template.md
+++ b/README.template.md
@@ -1,4 +1,4 @@
-# {{config.name}} API SDK
+# {{config.name}} API Client
 
 {{{shield.version}}}
 {{{shield.apiVersion}}}
@@ -38,7 +38,7 @@ console.log(newsletter._response.status); // 200
 ```
 
 #### Browser
-Download the browser SDK from `browser/{{config.name}}.js` or use our hosted version.
+Download the browser version from `browser/{{config.name}}.js` or use our hosted version.
 ```html
 <script src="{{{config.browserSdkUrl}}}"></script>
 <script>

--- a/browser/Cloudnode.js
+++ b/browser/Cloudnode.js
@@ -1,5 +1,5 @@
 /**
- * A client SDK for the Cloudnode API, written in TypeScript. [Documentation](https://github.com/cloudnode-pro/ts-client#documentation)
+ * A client library for the Cloudnode API, written in TypeScript. [Documentation](https://github.com/cloudnode-pro/ts-client#documentation)
  * @class
  */
 class Cloudnode {

--- a/gen/config.json
+++ b/gen/config.json
@@ -3,5 +3,5 @@
   "instanceName": "cloudnode",
   "baseUrl": "https://api.cloudnode.pro/v5/",
   "apiVersion": "5.12.0",
-  "browserSdkUrl": "https://cdn.jsdelivr.net/npm/cloudnode-ts@latest/browser/Cloudnode.min.js"
+  "browserUrl": "https://cdn.jsdelivr.net/npm/cloudnode-ts@latest/browser/Cloudnode.min.js"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudnode-ts",
   "version": "2.1.0",
-  "description": "A client SDK for the Cloudnode API, written in TypeScript. [Documentation](https://github.com/cloudnode-pro/ts-client#documentation)",
+  "description": "A client library for the Cloudnode API, written in TypeScript. [Documentation](https://github.com/cloudnode-pro/ts-client#documentation)",
   "main": "src/Cloudnode.js",
   "type": "module",
   "scripts": {

--- a/src/Cloudnode.d.ts
+++ b/src/Cloudnode.d.ts
@@ -1,6 +1,6 @@
 import Schema from "../gen/Schema";
 /**
- * A client SDK for the Cloudnode API, written in TypeScript. [Documentation](https://github.com/cloudnode-pro/ts-client#documentation)
+ * A client library for the Cloudnode API, written in TypeScript. [Documentation](https://github.com/cloudnode-pro/ts-client#documentation)
  * @class
  */
 declare class Cloudnode {

--- a/src/Cloudnode.js
+++ b/src/Cloudnode.js
@@ -1,5 +1,5 @@
 /**
- * A client SDK for the Cloudnode API, written in TypeScript. [Documentation](https://github.com/cloudnode-pro/ts-client#documentation)
+ * A client library for the Cloudnode API, written in TypeScript. [Documentation](https://github.com/cloudnode-pro/ts-client#documentation)
  * @class
  */
 class Cloudnode {

--- a/src/Cloudnode.ts
+++ b/src/Cloudnode.ts
@@ -1,7 +1,7 @@
 import Schema from "../gen/Schema";
 
 /**
- * A client SDK for the Cloudnode API, written in TypeScript. [Documentation](https://github.com/cloudnode-pro/ts-client#documentation)
+ * A client library for the Cloudnode API, written in TypeScript. [Documentation](https://github.com/cloudnode-pro/ts-client#documentation)
  * @class
  */
 class Cloudnode {


### PR DESCRIPTION
"SDK" is an inaccurate description for this library. This library only merely sends HTTP requests from generated TS methods as per the API spec.

An SDK in my view would be a library that builds on top of this software and returns instances of classes with methods that may execute complex logic and even send multiple different API requests. E.g. something like
```ts
// example for SDK in my view
const cloudnode = new Cloudnode();
const server = await cloudnode.getServer("some server");
await server.rename("new server name");
await server.tty.send("echo Hello World!");
await server.power.restart();
// etc.
```

We may develop such library in the future if it is needed.